### PR TITLE
fix: 회원인증 페이지 로그인, 회원가입 전환 버튼 생성

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,8 +3,9 @@
   <component name="ChangeListManager">
     <list default="true" id="8fb234ae-1f04-4040-b341-b104c47109b2" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/App.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/App.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/components/register/Signin.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/register/Signin.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/components/register/Signup.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/components/register/Signup.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/pages/Register.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/pages/Register.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/components/register/Signin.tsx
+++ b/src/components/register/Signin.tsx
@@ -86,6 +86,7 @@ const WholeWrap = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 auto;
+  flex: 1 1 0;
 `
 
 const Title = styled.h2`

--- a/src/components/register/Signup.tsx
+++ b/src/components/register/Signup.tsx
@@ -101,6 +101,7 @@ const WholeWrap = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 auto;
+  flex: 1 1 0;
 `
 
 const Title = styled.h2`

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,30 +1,60 @@
-import { useNavigate } from 'react-router-dom'
-import { useState, useEffect, FormEvent } from 'react'
-import Signup from '../components/register/Signup'
-import Signin from '../components/register/Signin'
-import { getAccessToken } from '../lib/apis/tokenStore'
+import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, FormEvent } from 'react';
+import Signup from '../components/register/Signup';
+import Signin from '../components/register/Signin';
+import { getAccessToken } from '../lib/apis/tokenStore';
+import styled from 'styled-components';
 
 
-type RegisterMode = 'signUp' | 'singIn'
+type RegisterMode = 'signUp' | 'signIn';
 
 const Register = () => {
-  const navigate = useNavigate()
-  const [mode, setMode] = useState<RegisterMode>('signUp')
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<RegisterMode>('signIn');
 
 
   const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault()
+    e.preventDefault();
+  }
+
+  const handleClickRegisterChange = () => {
+    if (mode === 'signIn') {
+      setMode('signUp');
+      return;
+    }
+    setMode('signIn');
   }
 
   useEffect(() => {
     if (getAccessToken()) {
-      navigate('/todo')
+      navigate('/todo');
     }
   }, [navigate])
 
-  return <div>
-    {mode === 'signUp' ? <Signup/> : <Signin/>}
-  </div>
+  return (
+    <Container>
+      {mode === 'signUp' ? <Signup /> : <Signin />}
+      <Button onClick={handleClickRegisterChange}>
+        {
+          mode === 'signIn' ? '회원가입 하러가기' : '로그인 하러가기'
+        }
+      </Button>
+    </Container>
+  )
 }
 
 export default Register
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Button = styled.button`
+  margin-top: 20px;
+  border: unset;
+  background-color: unset;
+  color: #0000ffc7;
+  font-weight: 600;
+  cursor: pointer;
+`;


### PR DESCRIPTION
- [x] 레지스터 페이지에서 로그인, 회원가입 전환하는 버튼을 생성했습니다.

<img width="215" alt="스크린샷 2022-12-23 오후 10 45 17" src="https://user-images.githubusercontent.com/97431021/209345952-50ab563b-90fd-4722-aea8-7edc86828a33.png">

<img width="233" alt="스크린샷 2022-12-23 오후 10 45 38" src="https://user-images.githubusercontent.com/97431021/209346000-c3f7551c-6314-4d1b-97d8-a3618b8c4b33.png">
